### PR TITLE
Links aktualisiert

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,9 +54,9 @@
       <div class="hero-unit visible-desktop">
         <h1>Arbeitskreise der ZaPF</h1>
         <p class="lead">Hier gibt es die Liste der Arbeitskreise der ZaPF als <img alt="HTML5" src="img/HTML5_Logo_32.png" />-App für dein Handy.</p>
-        <p><a class="btn btn-primary btn-large" href="https://vmp.ethz.ch/zapfwiki/index.php/Hauptseite">Mehr über die ZaPF »</a>
-		<a class='btn btn-primary btn-large' href='https://vmp.ethz.ch/zapfwiki/index.php/WiSe15'>Diese ZaPF im Wiki »</a>
-		<a class='btn btn-primary btn-large' href='http://ruebezahl.physik.uni-frankfurt.de/index.php/physik-gebaude/'>Lageplan »</a></p>
+        <p><a class="btn btn-primary btn-large" href="https://zapfwiki.de">Mehr über die ZaPF »</a>
+		<a class='btn btn-primary btn-large' href='https://zapfwiki.de'>Diese ZaPF im Wiki »</a>
+		<a class='btn btn-primary btn-large' href='https://zapf.in/'>Lageplan »</a></p>
       </div>
 
       <div id="completion" class="hero-unit visible-desktop hidden">


### PR DESCRIPTION
Das ZaPF-Wiki ist jetzt nicht mehr bei der ETH, sondern bei uns. Und die jeweils aktuelle ZaPF sollte unter zapf.in zu finden sein.
